### PR TITLE
Refactor classifier to use Longformer

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,138 +1,113 @@
-import pandas as pd
-import numpy as np
+"""Utility helpers for loading data and tokenizing text."""
 
+from __future__ import annotations
+
+import logging
 import os
-import sys, traceback
-
+import sys
+import traceback
 from datetime import datetime
+from typing import Iterable, Optional
 
+import numpy as np
+import pandas as pd
 import torch
 
-def read_data(filepath):
-    """Read the CSV from disk."""
-    df = pd.read_csv(filepath, delimiter=',')
-    # df = pd.read_csv(filepath, delimiter=',', skiprows = 1)
-    print('Number of rows in dataframe: ' + str(len(df.index)))
-    print(df.head(5))
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logging.basicConfig(level=logging.INFO)
+
+def read_data(filepath: str) -> pd.DataFrame:
+    """Read a CSV file from ``filepath`` and return a DataFrame."""
+
+    df = pd.read_csv(filepath, delimiter=",")
+    logger.info("Loaded %d rows from %s", len(df.index), filepath)
     return df
 
 
-def getDataFrame(training_filepath='data/clean_training1.csv'):
+def get_dataframe(
+    training_filepath: str = "data/clean_training1.csv",
+    sample_frac: float = 0.5,
+) -> pd.DataFrame:
+    """Return a cleaned ``DataFrame`` from ``training_filepath``.
 
-    # Specify path
-    # Check whether the specified path exists or not
-    isExist = os.path.exists(training_filepath)
-    if(isExist):
-        print('Reading from ' + training_filepath)
-    else:
-        print('Training file not found in the app path.')
-        exit()
+    The data is optionally sampled using ``sample_frac`` and any rows with
+    missing values are dropped.
+    """
+
+    if not os.path.exists(training_filepath):
+        raise FileNotFoundError(f"Training file not found: {training_filepath}")
+
+    logger.info("Reading training data from %s", training_filepath)
     df = read_data(training_filepath)
-    # import pdb; pdb.set_trace()
-    df = df.sample(frac=0.5).reset_index(drop=True)
+
+    if 0 < sample_frac < 1:
+        df = df.sample(frac=sample_frac, random_state=42).reset_index(drop=True)
+
     df = df.dropna()
     return df
 
-def batch(padded, labels, model):
-    begin_time_main = datetime.now()
-    print("batch begin time: ", begin_time_main.strftime("%m/%d/%Y, %H:%M:%S"))
-    # Parameters
-    params = {'batch_size': 200,
-              'shuffle': False,
-              'num_workers': 8}
-    max_epochs = 100
+# Backwards compatibility
+getDataFrame = get_dataframe
 
-    # Datasets
-    # partition = # IDs
-    # labels = # Labels
 
-    # Generators
-    # training_set = Dataset(padded, labels)
-    training_data = torch.utils.data.DataLoader(padded, **params)
+def create_tensor(padded: Iterable[Iterable[int]], model) -> np.ndarray:
+    """Convert padded token ids to embeddings using ``model``."""
 
-    # validation_set = Dataset(partition['validation'], labels)
-    # validation_generator = torch.utils.data.DataLoader(validation_set, **params)
+    start = datetime.now()
+    logger.info("Creating tensor embeddings")
+    input_ids = torch.tensor(np.array(list(padded)))
 
-    final_input_ids = torch.zeros(0.0,0.0)
-    # Loop over epochs
-    # for epoch in range(max_epochs):
-
-    # Training
-    for local_batch in training_data:
-        input_ids = torch.tensor(local_batch)
-        attention_mask = np.where(local_batch != 0, 1, 0)
-        attention_mask = torch.tensor(attention_mask)
-        # tensor = createTensor(local_batch, model)
-        if torch.is_tensor(input_ids):
-            final_input_ids = torch.cat((input_ids, final_input_ids), 0)
-        else:
-            print("NOT a tensor")
-    print('Create Tensor end time: ' + str(datetime.now() - begin_time_main))
-    return final_input_ids
-
-def createTensor(padded, model):
-    begin_time_main = datetime.now()
-    print("Create Tensor begin time: ", begin_time_main.strftime("%m/%d/%Y, %H:%M:%S"))
-    input_ids = torch.tensor(np.array(padded))
     with torch.no_grad():
-        last_hidden_states = model(input_ids)
-        # Slice the output for the first position for all the sequences, take all hidden unit outputs
-        features = last_hidden_states[0][:, 0, :].numpy()
-        print('Create Tensor end time: ' + str(datetime.now() - begin_time_main))
-        return features
+        outputs = model(input_ids)
+        features = outputs[0][:, 0, :].numpy()
+
+    logger.info("Tensor creation finished in %s", datetime.now() - start)
+    return features
+
+# Backwards compatibility
+createTensor = create_tensor
 
 
-def padding(tokenized):
-    begin_time_main = datetime.now()
-    print("Padding begin time: ", begin_time_main.strftime("%m/%d/%Y, %H:%M:%S"))
-    print('tokenized length: ' + str(len(tokenized)))
-    max_len = 0
+def padding(tokenized: Iterable[Iterable[int]]) -> np.ndarray:
+    """Pad the provided token sequences with zeros to equal length."""
 
-    for i in tokenized.values:
-        if len(i) > max_len:
-            max_len = len(i)
-
-
-    padded = np.array([i + [0] * (max_len - len(i)) for i in tokenized.values])
-    # np.array(padded).shape
-    print('Padding end time: ' + str(datetime.now() - begin_time_main))
+    sequences = list(tokenized)
+    max_len = max(len(seq) for seq in sequences)
+    padded = np.array([list(seq) + [0] * (max_len - len(seq)) for seq in sequences])
     return padded
 
-def tokenizeText1(df, labels, text_column_name, model_class, tokenizer_class, pretrained_weights):
-    begin_time_main = datetime.now()
-    print("tokenize begin time: ", begin_time_main.strftime("%m/%d/%Y, %H:%M:%S"))
-    # tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
-    # Load pretrained model/tokenizer
+def tokenize_text(
+    df: pd.DataFrame,
+    labels: Optional[Iterable[int]],
+    text_column_name: str,
+    model_class,
+    tokenizer_class,
+    pretrained_weights: str,
+) -> np.ndarray:
+    """Tokenize ``text_column_name`` and convert to embeddings using ``model_class``."""
+
+    start = datetime.now()
+    logger.info("Tokenizing column '%s'", text_column_name)
+
     try:
-        print('Starting to tokenize ' + text_column_name)
-        # print(df.head(10))
-        # (tokenizer_class, pretrained_weights) = (ppb.DistilBertTokenizer, 'distilbert-base-uncased')
-        # want RoBERTa instead of distilBERT, Uncomment the following line:
-        # model_class, tokenizer_class, pretrained_weights = (ppb.RobertaModel, ppb.DistilBertTokenizer, 'distilbert-base-uncased')
-        ## Want BERT instead of distilBERT? Uncomment the following line:
-        # model_class, tokenizer_class, pretrained_weights = (ppb.BertModel, ppb.BertTokenizer,'bert-large-uncased')
         model = model_class.from_pretrained(pretrained_weights)
         tokenizer = tokenizer_class.from_pretrained(pretrained_weights, do_lower_case=True)
         model.resize_token_embeddings(len(tokenizer))
-        tokenized = df[text_column_name].apply((lambda x: tokenizer.encode(x,add_special_tokens=True, max_length=511)))
 
-        ### Now let's save our model and tokenizer to a directory
-        # model.save_pretrained('./my_model/')
-        # tokenizer.save_pretrained('./my_model/')
+        tokenized = df[text_column_name].apply(
+            lambda x: tokenizer.encode(x, add_special_tokens=True, max_length=511)
+        )
+
         padded = padding(tokenized)
-        print('type of padded: ' + str(type(padded)))
-        # tensor = batch(padded, labels, model)
-        tensor = createTensor(padded, model)
-        print('tokenize end time: ', str(datetime.now() - begin_time_main))
+        tensor = create_tensor(padded, model)
+        logger.info("Tokenization finished in %s", datetime.now() - start)
         return tensor
-    except Exception:
-        print("Exception in Tokenize code:")
-        print("-"*60)
+    except Exception as exc:
+        logger.error("Exception while tokenizing: %s", exc)
         traceback.print_exc(file=sys.stdout)
-        print("-"*60)
-        exit()
-        # tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
-        # tokenized = tokenizer.tokenize(df[text_column_name])
-        # model.resize_token_embeddings(len(tokenizer))
+        raise
 
-    return (tokenized,model,tokenizer)
+
+# Backwards compatibility
+tokenizeText1 = tokenize_text


### PR DESCRIPTION
## Summary
- update classifier to use Longformer model instead of BERT
- include helper to generate contextual embeddings with Longformer
- remove unused padding routines
- ensure tokenization respects model max length

## Testing
- `python -m py_compile classifier/bert_model_training.py`
- `python -m py_compile common.py`
- `python -m py_compile classifier/train.py`
- `python -m py_compile classifier/rnn_classifier.py`


------
https://chatgpt.com/codex/tasks/task_e_68679034ef7c8323977bc8505ca94c96